### PR TITLE
API: remove `.base` modules from `api` module

### DIFF
--- a/src/artkit/api.py
+++ b/src/artkit/api.py
@@ -6,17 +6,14 @@ from fluxus import *
 from fluxus.functional import *
 
 from .model.diffusion import *
-from .model.diffusion.base import *
 from .model.diffusion.openai import *
 from .model.llm import *
 from .model.llm.anthropic import *
-from .model.llm.base import *
 from .model.llm.gemini import *
 from .model.llm.groq import *
 from .model.llm.huggingface import *
 from .model.llm.multi_turn import *
 from .model.llm.openai import *
 from .model.vision import *
-from .model.vision.base import *
 from .model.vision.openai import *
 from .util import *


### PR DESCRIPTION
The `.base` modules contain abstract base classes that are not typically used in user code.

This PR removes their definitions from the `artkit.api` module to reduce clutter (note that some of the other `.base` classes had already been removed previously, so this PR also creates more consistency).