### PR TITLE
DOC: Add fixed GitHub icon to top nav bar which links to our repo

### DIFF
--- a/sphinx/make/conf_base.py
+++ b/sphinx/make/conf_base.py
@@ -167,6 +167,13 @@ imgmath_use_preview = True
 html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/BCG-X-Official/artkit",
+            "icon": "fab fa-github",
+        },
+    ],
     "collapse_navigation": True,
     "show_nav_level": 1,
     "show_toc_level": 2,


### PR DESCRIPTION
## Description

This PR adds a permanent GitHub icon to the top navigation bar which links to our repo from the Sphinx documentation.

Currently, our built docs do not provide any fixed link to our repo.

### Currently there is no GitHub icon

<img width="424" alt="Screenshot 2024-06-25 at 10 47 05 AM" src="https://github.com/BCG-X-Official/artkit/assets/11166448/22a669c4-abbe-4fb5-a119-afa0498e2a49">

### PR adds a GitHub icon

![Screenshot 2024-06-25 at 10 47 16 AM](https://github.com/BCG-X-Official/artkit/assets/11166448/32a8d502-2f8f-4c5a-ba4f-ff09e28e3f4a)
