### PR TITLE
BUILD: Add backward compatibility for Python 3.10

### DIFF
--- a/.github/workflows/artkit-release-pipeline.yml
+++ b/.github/workflows/artkit-release-pipeline.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.10.14
 
       - name: Upgrade pip
         # Ensure we run the latest version of pip
@@ -144,10 +144,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.10.14
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.10.14
 
       - name: Display directory contents
         run: ls ${{ github.workspace }}
@@ -206,13 +206,16 @@ jobs:
     if: ${{ needs.detect_build_config_changes.outputs.conda_build_config_changed != '1' && github.event_name != 'schedule' && !startsWith(github.head_ref, 'dev/') && !startsWith(github.base_ref, 'release/') && !startsWith(github.ref, 'refs/heads/release/') }}
     strategy:
       matrix:
-        python-version: [ 3.11 ]
+        python-version: [ 3.10.14, 3.12 ]
         build-system: [ conda, tox ]
         pkg-dependencies: [ max, min ]
         exclude:
-          - python-version: 3.11
-            build-system: conda
+          - build-system: conda
             pkg-dependencies: min
+          - python-version: 3.12
+            pkg-dependencies: min
+          - python-version: 3.10.14
+            pkg-dependencies: max
 
     steps:
       - name: Checkout code
@@ -285,11 +288,11 @@ jobs:
     if: needs.detect_build_config_changes.outputs.conda_build_config_changed == '1' || (startsWith(github.head_ref, 'dev/') && startsWith(github.base_ref, 'release/')) || startsWith(github.ref, 'refs/heads/release/') || github.event_name == 'schedule'
     strategy:
       matrix:
-        python-version: [ 3.11, 3.12 ]
+        python-version: [ 3.10.14, 3.12 ]
         build-system: [ conda, tox ]
         pkg-dependencies: [ default, min, max ]
         exclude:
-          - python-version: 3.11
+          - python-version: 3.10.14
             pkg-dependencies: max
           - python-version: 3.12
             pkg-dependencies: default
@@ -401,7 +404,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.10.14
 
       - name: Checkout artkit
         uses: actions/checkout@v4
@@ -471,7 +474,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.10.14
 
       - name: Checkout artkit
         uses: actions/checkout@v4
@@ -581,7 +584,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.10.14
 
       - name: Retrieve current documentation versions from github-pages
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.16.0
     hooks:
       - id: pyupgrade
-        args: [--py311-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: black
         language: python
-        language_version: python311
+        language_version: python310
 
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
@@ -24,7 +24,7 @@ repos:
         name: flake8
         entry: flake8 --config tox.ini
         language: python
-        language_version: python311
+        language_version: python310
         additional_dependencies:
           - flake8-comprehensions ~= 3.10
         types: [ python ]
@@ -47,7 +47,7 @@ repos:
         args: [--config-file, pyproject.toml]
         files: \.pyi?$
         language: python
-        language_version: python311
+        language_version: python310
         pass_filenames: false
         additional_dependencies:
           - fluxus~=1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ For major contributions, reach out to the ARTKIT team in advance (ARTKIT@bcg.com
 
 The basic requirements for developing this library are:
 
-- [Python](https://www.python.org/downloads/) version 3.11.x or later
+- [Python](https://www.python.org/downloads/) 3.10 or later
 - [git](https://git-scm.com/downloads) for cloning and contributing to the library
 - [pip](https://pip.pypa.io/en/stable/installation/) or [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) for installing and managing Python libraries
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: artkit
 channels:
   - bcgx
+  - conda-forge
   - defaults
 dependencies:
   # Python

--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,10 @@
 name: artkit
 channels:
-  - conda-forge
   - bcgx
   - defaults
 dependencies:
   # Python
-  - python                   ~= 3.11.8
+  - python                   ~= 3.10.14
 
   # Additional libraries
   - fluxus                   ~= 1.0

--- a/pypi_description.rst
+++ b/pypi_description.rst
@@ -19,7 +19,7 @@ License
 .. |pypi| image:: https://badge.fury.io/py/artkit.svg
     :target: https://pypi.org/project/artkit/
 
-.. |python_versions| image:: https://img.shields.io/badge/python-3.11%7C3.12-blue.svg
+.. |python_versions| image:: https://img.shields.io/badge/python-3.10%7C3.12-blue.svg
     :target: https://www.python.org/downloads/
 
 .. |code_style| image:: https://img.shields.io/badge/code%20style-black-000000.svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires = [
     "typing_inspect    ~=0.7",
 ]
 
-requires-python = ">=3.11,<4a"
+requires-python = ">=3.10,<4a"
 
 [tool.flit.metadata.requires-extra]
 openai = [
@@ -87,7 +87,7 @@ no-binary.min = []
 [build.matrix.min]
 matplotlib          = "~=3.6.3"
 pandas              = "~=2.1"
-python              = "==3.11"
+python              = ">=3.10.14,<3.11a"
 gamma-pytools       = "~=3.0.0"
 fluxus              = "~=1.0.0"
 typing_inspect      = "~=0.7.1"
@@ -117,7 +117,7 @@ torch               = ">=2.3"
 [tool.black]
 required-version = '24.4.2'
 line-length = 88
-target_version = ['py311']
+target_version = ['py310']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/sphinx/source/contributor_guide/setup.rst
+++ b/sphinx/source/contributor_guide/setup.rst
@@ -10,7 +10,7 @@ Pre-requisites
 
 The basic requirements for developing this library are:
 
--  `Python <https://www.python.org/downloads/>`__ version 3.11 or later
+-  `Python <https://www.python.org/downloads/>`__ 3.10 or later
 -  `git <https://git-scm.com/downloads>`__ for cloning and contributing to the library
 -  `pip <https://pip.pypa.io/en/stable/installation/>`__ or `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>`__ for installing and managing Python libraries
 

--- a/src/artkit/model/cache/_cache.py
+++ b/src/artkit/model/cache/_cache.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
+import sys
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -465,7 +466,11 @@ def _parse_iso_utc(iso_timestamp: str) -> datetime:
     :return: the corresponding datetime object in UTC
     """
     try:
-        return datetime.fromisoformat(iso_timestamp + "Z")
+        if sys.version_info >= (3, 11):
+            return datetime.fromisoformat(iso_timestamp + "Z")
+        else:
+            # The "Z" suffix is not supported in Python versions before 3.11
+            return datetime.fromisoformat(iso_timestamp + "+00:00")
     except ValueError:
         # Try to parse the iso_timestamp without the 'Z' suffix
         return datetime.fromisoformat(iso_timestamp).astimezone(timezone.utc)

--- a/src/artkit/model/llm/base/_llm.py
+++ b/src/artkit/model/llm/base/_llm.py
@@ -20,10 +20,10 @@ Implementation of llm module.
 
 import copy
 import logging
-
-# imports
 from abc import ABCMeta, abstractmethod
-from typing import Any, Generic, Self, TypeVar, final
+from typing import Any, Generic, TypeVar, final
+
+from typing_extensions import Self
 
 from pytools.api import appenddoc, inheritdoc, subsdoc
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 envlist = py3, py3-custom-deps
 skip_missing_interpreters = true
 isolated_build = true
-minversion = 3.11
+minversion = 3.10
 distshare= {toxinidir}/dist/tox
 
 [testenv]


### PR DESCRIPTION
- [x] Have you followed our [PR guidelines](https://bcg-x-official.github.io/artkit/contributor_guide/how_to_contribute.html#pull-request-pr-guidelines) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/BCG-X-Official/artkit/pulls) for the same update/change?

## Description

*artkit* can now be used with Python versions back to 3.10, allowing use with popular services such as Google Colab.

## Issue number and link:

## New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally before submission?

## Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
