### PR TITLE
API: Expose base models in API package

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+*artkit* 1.0.3
+--------------
+
+- API: Key base classes are now exposed through the :mod:`artkit.api` module:
+  :class:`.ChatModel`, :class:`.CompletionModel`, :class:`.DiffusionModel`, and
+  :class:`.VisionModel`. These classes are frequently used in type hints, and this
+  change makes it easier to import them without having to know the exact module
+  they are defined in.
+
+
 *artkit* 1.0.2
 --------------
 

--- a/src/artkit/api.py
+++ b/src/artkit/api.py
@@ -45,6 +45,7 @@ from .model.llm.groq import *
 from .model.llm.huggingface import *
 from .model.llm.multi_turn import *
 from .model.llm.openai import *
+from .model.llm.base import ChatModel
 from .model.vision import *
 from .model.vision.openai import *
 from .util import *

--- a/src/artkit/api.py
+++ b/src/artkit/api.py
@@ -40,12 +40,12 @@ from .model.diffusion import *
 from .model.diffusion.openai import *
 from .model.llm import *
 from .model.llm.anthropic import *
+from .model.llm.base import ChatModel
 from .model.llm.gemini import *
 from .model.llm.groq import *
 from .model.llm.huggingface import *
 from .model.llm.multi_turn import *
 from .model.llm.openai import *
-from .model.llm.base import ChatModel
 from .model.vision import *
 from .model.vision.openai import *
 from .util import *

--- a/src/artkit/api.py
+++ b/src/artkit/api.py
@@ -48,8 +48,8 @@ from .model.llm.huggingface import *
 from .model.llm.multi_turn import *
 from .model.llm.openai import *
 from .model.vision import *
-from .model.vision.openai import *
 from .model.vision.base import VisionModel
+from .model.vision.openai import *
 from .util import *
 
 

--- a/src/artkit/api.py
+++ b/src/artkit/api.py
@@ -37,10 +37,11 @@ __globals_original = set(globals().keys())
 
 from .flow import *
 from .model.diffusion import *
+from .model.diffusion.base import DiffusionModel
 from .model.diffusion.openai import *
 from .model.llm import *
 from .model.llm.anthropic import *
-from .model.llm.base import ChatModel
+from .model.llm.base import ChatModel, CompletionModel
 from .model.llm.gemini import *
 from .model.llm.groq import *
 from .model.llm.huggingface import *
@@ -48,6 +49,7 @@ from .model.llm.multi_turn import *
 from .model.llm.openai import *
 from .model.vision import *
 from .model.vision.openai import *
+from .model.vision.base import VisionModel
 from .util import *
 
 

--- a/src/artkit/model/llm/base/_llm.py
+++ b/src/artkit/model/llm/base/_llm.py
@@ -36,7 +36,6 @@ log = logging.getLogger(__name__)
 
 __all__ = [
     "ChatModel",
-    "ChatModel",
     "ChatModelConnector",
     "CompletionModel",
     "CompletionModelConnector",


### PR DESCRIPTION
## Description

This PR exposes key base classes through the `artkit.api` module:
- `ChatModel`
- `CompletionModel`
- `VisionModel`
- `DiffusionModel`

While these classes cannot be instantiated directly, they are frequently used for type hints and this change makes it easier to access them (rather than importing them from their actual `.base` module)

## Issue number and link:

https://github.com/BCG-X-Official/artkit/issues/39

## PR checks

- [x] Have you followed our [PR guidelines](https://bcg-x-official.github.io/artkit/contributor_guide/how_to_contribute.html#pull-request-pr-guidelines) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/BCG-X-Official/artkit/pulls) for the same update/change?

## New Feature Submissions:

1. [x] Does your submission pass tests?
2. [ ] Have you lint your code locally before submission?

## Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
