### PR TITLE
DOCS: clarify that pre-commit is already installed via optional dev deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,9 +145,9 @@ Pandoc is required to render Jupyter Notebooks for building the sphinx documenta
 
 [Pre-commit hooks](https://pre-commit.com/) are strongly encouraged to enforce uniform coding standards across all contributors:
 
-First, install pre-commit within your virtual environment
+First, confirm pre-commit is installed within your virtual environment. It should have been installed via the optional dev dependencies `pip install -e ".[dev]"`.
 ```
-pip install pre-commit
+pip freeze | grep pre-commit
 ```
 
 Next, run pre-commit's install command to create a Git hook script configured by `.pre-commit-config.yaml`.


### PR DESCRIPTION
## Description

Minor clarification in CONTRIBUTING.md documentation. Pre-commit is already listed as one of the optional dev dependencies and does not need to be installed separately to setup hooks in a contributor's local environment.

## Issue number and link:

## PR checks:

- [x] Have you followed our [PR guidelines](https://bcg-x-official.github.io/artkit/contributor_guide/how_to_contribute.html#pull-request-pr-guidelines) document
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/BCG-X-Official/artkit/pulls) for the same update/change?
- [x] Have you set these PR fields: Reviewers, Assignees, Labels, Milestones
- [x] Have you updated `RELEASE_NOTES.rst`, if applicable?
- [x] Have you updated existing and/or created new unit tests for your changes?
