### PR TITLE
BUILD: add prefix to Veracode scan number

### DIFF
--- a/.github/workflows/artkit-release-pipeline.yml
+++ b/.github/workflows/artkit-release-pipeline.yml
@@ -384,7 +384,7 @@ jobs:
         uses: veracode/veracode-uploadandscan-action@master
         with:
           appname: 'artkit'
-          version: '${{ github.run_number }}'
+          version: '3.1.${{ github.run_number }}'
           filepath: 'static_scan/archive.zip'
           vid: '${{ secrets.VERACODE_API_ID }}'
           vkey: '${{ secrets.VERACODE_API_KEY }}'


### PR DESCRIPTION
## Description

Veracode scan triggers have been failing because of clashing scan numbers which are set in the Veracode job within the release pipeline. Veracode support recommended adding this prefix to avoid the conflicts.

## Issue number and link:

## PR checks:

- [x] Have you followed our [PR guidelines](https://bcg-x-official.github.io/artkit/contributor_guide/how_to_contribute.html#pull-request-pr-guidelines) document
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/BCG-X-Official/artkit/pulls) for the same update/change?
- [x] Have you set these PR fields: Reviewers, Assignees, Labels, Milestones
- [ ] Have you updated `RELEASE_NOTES.rst`, if applicable?
- [ ] Have you updated existing and/or created new unit tests for your changes?
