### PR TITLE
TEST: Potential fix for limiting recursion

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -6,7 +6,7 @@ Release Notes
 
 This is a bugfix release containing updates for a failing unit test and enhancements to historical release notes.
 
-- TEST: Fix `test_huggingface_retry() <https://github.com/BCG-X-Official/artkit/blob/1.0.x/test/artkit_test/model/llm/huggingface_tests/test_hugging_face.py>` where the session was not mocked correctly
+- TEST: Fix `test_huggingface_retry() <https://github.com/BCG-X-Official/artkit/blob/1.0.x/test/artkit_test/model/llm/huggingface_tests/test_hugging_face.py>`_ where the session was not mocked correctly
 - DOC: Retroactively updated release notes for more consistent quality and detail e.g. hyperlinking class definitions 
 
 *artkit* 1.0.7
@@ -14,7 +14,7 @@ This is a bugfix release containing updates for a failing unit test and enhancem
 
 This release adds access to Google's Vertex AI model and fixes the links in the documentation.
 
-- API: Added `VertexAIChat <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/vertexai/_vertexai.py>` to grant users access to Gemini models deployed on Google Vertex AI.
+- API: Added `VertexAIChat <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/vertexai/_vertexai.py>`_ to grant users access to Gemini models deployed on Google Vertex AI.
 - DOC: Fix broken links on the sphinx homepage
 
 *artkit* 1.0.6
@@ -22,8 +22,8 @@ This release adds access to Google's Vertex AI model and fixes the links in the 
 
 This release expands ARTKIT's connectivity to include any GenAI application with an exposed HTTP endpoint enabling evaluations of virtually any custom target system.
 
-- API: Added the `HTTPXChatConnector <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/base/_httpx_chat_connector.py>` class which requires further customization by a user for implementation but considerably expands ARTKIT's connectivity with custom target systems.
-- DOC: Added section `Calling custom endpoints via HTTP <https://github.com/BCG-X-Official/artkit/blob/1.0.x/sphinx/source/user_guide/advanced_tutorials/creating_new_model_classes.ipynb>` to guide implementation of the HTTPX connector
+- API: Added the `HTTPXChatConnector <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/base/_httpx_chat_connector.py>`_ class which requires further customization by a user for implementation but considerably expands ARTKIT's connectivity with custom target systems.
+- DOC: Added section `Calling custom endpoints via HTTP <https://github.com/BCG-X-Official/artkit/blob/1.0.x/sphinx/source/user_guide/advanced_tutorials/creating_new_model_classes.ipynb>`_ to guide implementation of the HTTPX connector
 
 *artkit* 1.0.5
 --------------
@@ -32,14 +32,14 @@ This release adds access to the Titan diffusion model in AWS bedrock and improve
 
 - BUILD: Add prefix to veracode scan number
 - DOC: Add clarifying documentation including links, badges, and extra details on dev dependencies 
-- API: Add `TitanDiffusion <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/diffusion/bedrock/_titan.py>` to enable users to access Titan diffusion models.
+- API: Add `TitanDiffusion <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/diffusion/bedrock/_titan.py>`_ to enable users to access Titan diffusion models.
 
 *artkit* 1.0.4
 --------------
 
 This release provides direct ARTKIT access to AWS Bedrock models.
 
-- API: Added `TitanBedrockChat <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/bedrock/_titan.py>` to enable users to access models deployed on AWS Bedrock.
+- API: Added `TitanBedrockChat <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/bedrock/_titan.py>`_ to enable users to access models deployed on AWS Bedrock.
 
 *artkit* 1.0.3
 --------------

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+*artkit* 1.0.8
+--------------
+
+- TEST: Fix hugging face retry logic in tests where the session was not mocked correctly
+- DOC: Add key takeaways for each release in the release notes 
+
 *artkit* 1.0.7
 --------------
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,26 +4,26 @@ Release Notes
 *artkit* 1.0.8
 --------------
 
-This release fixes a breaking unit test and adds key takeaways for each release in the release notes.
+This is a bugfix release containing updates for a failing unit test and enhancements to historical release notes.
 
-- TEST: Fix hugging face retry logic in tests where the session was not mocked correctly
-- DOC: Add key takeaways for each release in the release notes 
+- TEST: Fix `test_huggingface_retry() <https://github.com/BCG-X-Official/artkit/blob/1.0.x/test/artkit_test/model/llm/huggingface_tests/test_hugging_face.py>` where the session was not mocked correctly
+- DOC: Retroactively updated release notes for more consistent quality and detail e.g. hyperlinking class definitions 
 
 *artkit* 1.0.7
 --------------
 
 This release adds access to Google's Vertex AI model and fixes the links in the documentation.
 
-- API: Added `VertexAIChat <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/vertexai/_vertexai.py>`_ to enable users to access Gemini models deployed on Google Vertex AI.
-- DOC: Fix links on the sphinx homepage
+- API: Added `VertexAIChat <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/vertexai/_vertexai.py>` to grant users access to Gemini models deployed on Google Vertex AI.
+- DOC: Fix broken links on the sphinx homepage
 
 *artkit* 1.0.6
 --------------
 
 This release expands ARTKIT's connectivity to include any GenAI application with an exposed HTTP endpoint enabling evaluations of virtually any custom target system.
 
-- API: Added the `HTTPXChatConnector <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/base/_httpx_chat_connector.py>` which requires further customization by a user for implementation.
-- DOC: Added section `Calling custom endpoints via HTTP <https://github.com/BCG-X-Official/artkit/blob/1.0.x/sphinx/source/user_guide/advanced_tutorials/creating_new_model_classes.ipynb>` to guide implementation of the connector
+- API: Added the `HTTPXChatConnector <https://github.com/BCG-X-Official/artkit/blob/1.0.x/src/artkit/model/llm/base/_httpx_chat_connector.py>` class which requires further customization by a user for implementation but considerably expands ARTKIT's connectivity with custom target systems.
+- DOC: Added section `Calling custom endpoints via HTTP <https://github.com/BCG-X-Official/artkit/blob/1.0.x/sphinx/source/user_guide/advanced_tutorials/creating_new_model_classes.ipynb>` to guide implementation of the HTTPX connector
 
 *artkit* 1.0.5
 --------------

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,8 @@ Release Notes
 *artkit* 1.0.8
 --------------
 
+This release fixes a breaking unit test and adds key takeaways for each release in the release notes.
+
 - TEST: Fix hugging face retry logic in tests where the session was not mocked correctly
 - DOC: Add key takeaways for each release in the release notes 
 

--- a/test/artkit_test/model/llm/huggingface_tests/test_hugging_face.py
+++ b/test/artkit_test/model/llm/huggingface_tests/test_hugging_face.py
@@ -126,39 +126,25 @@ async def test_huggingface_retry(
     zephyr_7b_tokenizer: PreTrainedTokenizerBase,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    with patch("aiohttp.ClientSession") as MockClientSession:
+    # Mock the get_client method to return a mock client
+    with patch.object(hugging_face_chat, "get_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
 
-        # Mock the response object
-        mock_post = AsyncMock()
-        mock_post.read.return_value = b'[{"generated_text": "blue"}]'
-        mock_post.json.return_value = {"error": "Rate limit exceeded"}
-        mock_post.return_value.status = 429
-
-        # Request info mock
-        request_info = AsyncMock()
-        request_info.real_url = (
-            "https://api-inference.huggingface.co/models/HuggingFaceH4/zephyr-7b-beta"
-        )
-
-        def f() -> None:
+        # Define the side effect function for text_generation
+        async def mock_text_generation(*args: Any, **kwargs: Any) -> None:
+            request_info = Mock()
+            request_info.real_url = "https://api-inference.huggingface.co/models/HuggingFaceH4/zephyr-7b-beta"
             err = ClientResponseError(
                 request_info=request_info,
-                history=AsyncMock(),
+                history=(),
                 status=429,
                 message="Rate limit exceeded",
             )
             raise err
 
-        mock_post.raise_for_status = f
-
-        # Set up the mock connection object
-        mock_connection = AsyncMock()
-        mock_connection.post.return_value = mock_post
-        MockClientSession.return_value = mock_connection
-
-        # Mock session close to prevent recursive close calls
-        mock_close = AsyncMock()
-        mock_connection.close = mock_close  # Avoid recursion on session close
+        # Set the side effect
+        mock_client.text_generation.side_effect = mock_text_generation
 
         # Get number of awaited retries
         n_retries = hugging_face_chat.max_retries
@@ -172,7 +158,7 @@ async def test_huggingface_retry(
                     "Your job is to answer a quiz question with a single word, "
                     "lowercase, with no punctuation"
                 ).get_response(message="What color is the sky?")
-            assert mock_connection.post.call_count == n_retries
+            assert mock_client.text_generation.call_count == n_retries
 
         assert (
             len(

--- a/test/artkit_test/model/llm/huggingface_tests/test_hugging_face.py
+++ b/test/artkit_test/model/llm/huggingface_tests/test_hugging_face.py
@@ -156,6 +156,10 @@ async def test_huggingface_retry(
         mock_connection.post.return_value = mock_post
         MockClientSession.return_value = mock_connection
 
+        # Mock session close to prevent recursive close calls
+        mock_close = AsyncMock()
+        mock_connection.close = mock_close  # Avoid recursion on session close
+
         # Get number of awaited retries
         n_retries = hugging_face_chat.max_retries
 


### PR DESCRIPTION
## Description

As seen below, recursion is happening when the huggingface_hub's `_async_client` function is calling `session.close()`. Instead of further mocking the client session and overriding the close function, we fixed this issue by mocking the `client` itself to mock the text generation that happens, sidestepping the recursion error while testing the retry logic correctly.

### Relevant error log:

`test/artkit_test/model/llm/huggingface_tests/test_hugging_face.py:171`

`../../../micromamba/envs/artkit/lib/python3.10/site-packages/huggingface_hub/inference/_generated/_async_client.py:2677: in close_session
    await session._close()
   RecursionError: maximum recursion depth exceeded while calling a Python object
!!! Recursion detected (same locals & position)`
## Issue number and link:

## PR checks:

- [x] Have you followed our [PR guidelines](https://bcg-x-official.github.io/artkit/contributor_guide/how_to_contribute.html#pull-request-pr-guidelines) document
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/BCG-X-Official/artkit/pulls) for the same update/change?
- [x] Have you set these PR fields: Reviewers, Assignees, Labels, Milestones
- [x] Have you updated `RELEASE_NOTES.rst`, if applicable?
- [x] Have you updated existing and/or created new unit tests for your changes?
