### PR TITLE
DOC: Fix building_your_first_artkit_pipeline.ipynb

### DIFF
--- a/sphinx/source/user_guide/introduction_to_artkit/building_your_first_artkit_pipeline.ipynb
+++ b/sphinx/source/user_guide/introduction_to_artkit/building_your_first_artkit_pipeline.ipynb
@@ -443,12 +443,7 @@
     ")\n",
     "\n",
     "\n",
-    "# Input prompt\n",
-    "prompt = {'prompt': 'What is the answer to the Ultimate Question \\\n",
-    "          of Life, the Universe, and Everything?'}\n",
-    "\n",
-    "\n",
-    "# Run step with the input prompt\n",
+    "# Run step with the same input prompt from the previous cell\n",
     "result = ak.run(steps=step_gpt4, input=question)\n",
     "result.to_frame()"
    ]


### PR DESCRIPTION
## Description

This PR is to remove an unused variable, `prompt`, from `building_your_first_artkit_pipeline.ipynb` as described in Issue #70.

It turns out that `prompt` is a duplicate of another variable named `question` in the previous cell.

In addition, `question` is used in a function call in the same cell as `prompt`, and since the definition of `question` is not in the immediate context (it is in the previous cell), I thought that it would be nice to modify the comment above the function call so that its use might be more clear to readers.

## Issue number and link: #70

## PR checks:

- [x] Have you followed our [PR guidelines](https://bcg-x-official.github.io/artkit/contributor_guide/how_to_contribute.html#pull-request-pr-guidelines) document
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/BCG-X-Official/artkit/pulls) for the same update/change?
- [ ] Have you set these PR fields: Reviewers, Assignees, Labels, Milestones
- [ ] Have you updated `RELEASE_NOTES.rst`, if applicable?
- [ ] Have you updated existing and/or created new unit tests for your changes?
